### PR TITLE
Index command now indexes all record kinds by default.

### DIFF
--- a/docs/source/faqs.rst
+++ b/docs/source/faqs.rst
@@ -399,7 +399,8 @@ Below we give an example of how to index and publish catalogs programmatically:
        # Index the directory named tools.
        index(
               directory="tools",
-              kind="tool",
+              tools=True,
+              prompts=False
        )
 
        # Publish our local catalog.
@@ -415,7 +416,7 @@ The script above is equivalent to running the following CLI commands:
 
 .. code-block:: bash
 
-       agentc index tools --kind tool
+       agentc index tools --no-prompts
 
        export AGENT_CATALOG_CONN_STRING=localhost
        export AGENT_CATALOG_USERNAME=Administrator

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -77,7 +77,7 @@ Both tool builders and prompt builders (i.e., agent builders) will follow this w
 
    .. code-block:: bash
 
-    agentc index [DIRECTORY] --kind [tool|prompt]
+    agentc index [DIRECTORY] --prompts/no-prompts --tools/no-tools
 
    ``[DIRECTORY]`` refers to the directory containing your tools/prompts.
    This command will create a local catalog and your items will be in the newly created :file:`./agent-catalog` folder.

--- a/libs/agentc_cli/agentc_cli/cmds/index.py
+++ b/libs/agentc_cli/agentc_cli/cmds/index.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 def cmd_index(
     source_dirs: list[str | os.PathLike],
-    kind: typing.Literal["tool", "prompt"],
+    kinds: list[typing.Literal["tool", "prompt"]],
     embedding_model_name: str = DEFAULT_EMBEDDING_MODEL,
     dry_run: bool = False,
     ctx: Context = None,
@@ -73,9 +73,6 @@ def cmd_index(
         else:
             raise e
 
-    # TODO: The kind needs a security check as it's part of the path?
-    catalog_path = pathlib.Path(ctx.catalog) / (kind + DEFAULT_CATALOG_NAME)
-
     meta_version = MetaVersion(
         schema_version=CATALOG_SCHEMA_VERSION,
         library_version=lib_version(),
@@ -91,24 +88,26 @@ def cmd_index(
     else:
         printer = click.secho
 
-    printer(DASHES, fg=KIND_COLORS[kind])
-    printer(kind.upper(), bold=True, fg=KIND_COLORS[kind])
-    printer(DASHES, fg=KIND_COLORS[kind])
-    next_catalog = index_catalog(
-        embedding_model,
-        meta_version,
-        version,
-        get_path_version,
-        kind,
-        catalog_path,
-        source_dirs,
-        scan_directory_opts=DEFAULT_SCAN_DIRECTORY_OPTS,
-        printer=printer,
-        print_progress=True,
-        max_errs=DEFAULT_MAX_ERRS,
-    )
-
-    if not dry_run:
-        next_catalog.dump(catalog_path)
-        click.secho("\nCatalog successfully indexed!", fg="green")
-    click.secho(DASHES, fg=KIND_COLORS[kind])
+    for kind in kinds:
+        # TODO: The kind needs a security check as it's part of the path?
+        catalog_path = pathlib.Path(ctx.catalog) / (kind + DEFAULT_CATALOG_NAME)
+        printer(DASHES, fg=KIND_COLORS[kind])
+        printer(kind.upper(), bold=True, fg=KIND_COLORS[kind])
+        printer(DASHES, fg=KIND_COLORS[kind])
+        next_catalog = index_catalog(
+            embedding_model,
+            meta_version,
+            version,
+            get_path_version,
+            kind,
+            catalog_path,
+            source_dirs,
+            scan_directory_opts=DEFAULT_SCAN_DIRECTORY_OPTS,
+            printer=printer,
+            print_progress=True,
+            max_errs=DEFAULT_MAX_ERRS,
+        )
+        if not dry_run:
+            next_catalog.dump(catalog_path)
+            click.secho("\nCatalog successfully indexed!", fg="green")
+        click.secho(DASHES, fg=KIND_COLORS[kind])

--- a/libs/agentc_cli/agentc_cli/cmds/index.py
+++ b/libs/agentc_cli/agentc_cli/cmds/index.py
@@ -107,7 +107,7 @@ def cmd_index(
             print_progress=True,
             max_errs=DEFAULT_MAX_ERRS,
         )
-        if not dry_run:
+        if not dry_run and len(next_catalog.catalog_descriptor.items) > 0:
             next_catalog.dump(catalog_path)
             click.secho("\nCatalog successfully indexed!", fg="green")
         click.secho(DASHES, fg=KIND_COLORS[kind])

--- a/libs/agentc_cli/agentc_cli/main.py
+++ b/libs/agentc_cli/agentc_cli/main.py
@@ -419,10 +419,17 @@ def find(
 @click_main.command()
 @click.argument("source_dirs", nargs=-1)
 @click.option(
-    "--kind",
-    default="tool",
-    type=click.Choice(["tool", "prompt"], case_sensitive=False),
-    help="Kind of items to index into the local catalog.",
+    "--prompts/--no-prompts",
+    is_flag=True,
+    default=True,
+    help="Flag to (avoid) ignoring prompt when indexing source files into the local catalog.",
+    show_default=True,
+)
+@click.option(
+    "--tools/--no-tools",
+    is_flag=True,
+    default=True,
+    help="Flag to (avoid) ignoring tools when indexing source files into the local catalog.",
     show_default=True,
 )
 @click.option(
@@ -440,7 +447,7 @@ def find(
     show_default=True,
 )
 @click.pass_context
-def index(ctx, source_dirs, kind, embedding_model, dry_run):
+def index(ctx, source_dirs, tools, prompts, embedding_model, dry_run):
     """Walk the source directory trees (SOURCE_DIRS) to index source files into the local catalog.
     Source files that will be scanned include *.py, *.sqlpp, *.yaml, etc."""
 
@@ -450,10 +457,21 @@ def index(ctx, source_dirs, kind, embedding_model, dry_run):
             "Please use the command 'agentc index --help' for more information."
         )
 
+    kinds = list()
+    if tools:
+        kinds.append("tool")
+    if prompts:
+        kinds.append("prompt")
+    if len(kinds) == 0:
+        raise ValueError(
+            "No kinds specified!\n"
+            "Please specify at least one of 'tool' (via --tools) or 'prompt' (via --prompts) to index the "
+            "source directories."
+        )
     cmd_index(
         ctx=ctx.obj,
         source_dirs=source_dirs,
-        kind=kind,
+        kinds=kinds,
         embedding_model_name=embedding_model,
         dry_run=dry_run,
     )

--- a/libs/agentc_cli/agentc_cli/main.py
+++ b/libs/agentc_cli/agentc_cli/main.py
@@ -422,7 +422,7 @@ def find(
     "--prompts/--no-prompts",
     is_flag=True,
     default=True,
-    help="Flag to (avoid) ignoring prompt when indexing source files into the local catalog.",
+    help="Flag to (avoid) ignoring prompts when indexing source files into the local catalog.",
     show_default=True,
 )
 @click.option(

--- a/libs/agentc_cli/tests/test_click.py
+++ b/libs/agentc_cli/tests/test_click.py
@@ -41,7 +41,7 @@ def test_index(tmp_path):
             pathlib.Path(tool_folder / tool.parent.name).mkdir(exist_ok=True)
             shutil.copy(tool, tool_folder / tool.parent.name / (uuid.uuid4().hex + tool.suffix))
         shutil.copy(resources_folder / "_good_spec.json", tool_folder / "_good_spec.json")
-        invocation = runner.invoke(click_main, ["index", str(tool_folder.absolute())])
+        invocation = runner.invoke(click_main, ["index", str(tool_folder.absolute()), "--no-prompts"])
 
         # We should see 8 files scanned and 9 tools indexed.
         output = invocation.output

--- a/libs/agentc_core/agentc_core/indexer/__init__.py
+++ b/libs/agentc_core/agentc_core/indexer/__init__.py
@@ -1,5 +1,5 @@
+from .indexer import AllIndexers
 from .indexer import augment_descriptor
-from .indexer import source_indexers
 from .indexer import vectorize_descriptor
 
-__all__ = ["vectorize_descriptor", "augment_descriptor", "source_indexers"]
+__all__ = ["vectorize_descriptor", "augment_descriptor", "AllIndexers"]

--- a/libs/agentc_core/agentc_core/record/descriptor.py
+++ b/libs/agentc_core/agentc_core/record/descriptor.py
@@ -35,6 +35,12 @@ class RecordKind(enum.StrEnum):
     RawPrompt = "raw_prompt"
     JinjaPrompt = "jinja_prompt"
 
+    def is_prompt(self) -> bool:
+        return self in [RecordKind.RawPrompt, RecordKind.JinjaPrompt]
+
+    def is_tool(self) -> bool:
+        return self not in [RecordKind.RawPrompt, RecordKind.JinjaPrompt]
+
 
 class RecordDescriptor(pydantic.BaseModel):
     """This model represents a tool's persistable description or metadata."""

--- a/libs/agentc_testing/agentc_testing/repo.py
+++ b/libs/agentc_testing/agentc_testing/repo.py
@@ -80,9 +80,9 @@ def initialize_repo(
     # ...otherwise, we'll call the index command.
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
     if repo_kind not in [ExampleRepoKind.INDEXED_CLEAN_PROMPTS_TRAVEL, ExampleRepoKind.PUBLISHED_PROMPTS_TRAVEL]:
-        output.append(click_runner.invoke(click_command, ["index", "tools", "--kind", "tool"] + (index_args or [])))
+        output.append(click_runner.invoke(click_command, ["index", "tools", "--no-prompts"] + (index_args or [])))
     if repo_kind not in [ExampleRepoKind.INDEXED_CLEAN_TOOLS_TRAVEL, ExampleRepoKind.PUBLISHED_TOOLS_TRAVEL]:
-        output.append(click_runner.invoke(click_command, ["index", "prompts", "--kind", "prompt"] + (index_args or [])))
+        output.append(click_runner.invoke(click_command, ["index", "prompts", "--no-tools"] + (index_args or [])))
     if repo_kind not in [
         ExampleRepoKind.PUBLISHED_ALL_TRAVEL,
         ExampleRepoKind.PUBLISHED_TOOLS_TRAVEL,


### PR DESCRIPTION
- The index command now indexes all kinds by default.
- Fixed bug where kind=prompt included tools in the prompt-catalog.json file (and vice versa).
- Removed "kind" option in index command in favor of "--prompts/--no-prompts" and "--tools/--no-tools" flags.