### PR TITLE
Make 'output' field in .sqlpp tools optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # agent-catalog (Couchbase Agent Catalog)
+
 [![CI/CD Tests](https://github.com/couchbaselabs/agent-catalog/actions/workflows/tests.yaml/badge.svg)](https://github.com/couchbaselabs/agent-catalog/actions/workflows/tests.yaml)
 
 The mono-repo for the Couchbase Agent Catalog project.
@@ -9,50 +10,61 @@ The mono-repo for the Couchbase Agent Catalog project.
 
 (in the works!)
 
-### Installing from Git (with Poetry)
+### Installing from Source (with Pip)
 
 1. Make sure you have Python 3.12 and [Poetry](https://python-poetry.org/docs/#installation) installed!
-2. In your `pyproject.toml` file, add the following line in the `[tool.poetry.dependencies]` section:
 
-   ```toml
-   agentc = { git = "git@github.com:couchbaselabs/agent-catalog.git", subdirectory = "libs/agentc", extras = ["langchain"] }
-   ```
-
-3. Now run `poetry update` to automatically download the `agentc` package into your Poetry environment.
-
-### Installing from Source (with Poetry + Pip)
-
-1. Make sure you have Python 3.12 and [Poetry](https://python-poetry.org/docs/#installation) installed!
-2. Clone this repository. Make sure you have your SSH key setup!
+2. Clone this repository.
+   Make sure you have your SSH key setup!
 
    ```bash
    git clone git@github.com:couchbaselabs/agent-catalog.git
    ```
 
-3. Build the `agentc` package using Poetry.
+3. You are now ready to install the Agent Catalog package!
+   Using your project's Python environment, execute the following command to install a local package with `pip`:
+
+   ```bash
+   cd agent-catalog
+   source $MY_PYTHON_ENVIRONMENT
+
+   # Install the agentc package.
+   pip install libs/agentc
+   ```
+
+   If you are interested in building a ``.whl`` file (for later use in ``.whl``-based installs), use :command:`poetry`
+   directly:
 
    ```bash
    cd libs/agentc
    poetry build
    ```
 
-4. You should now have a `dist` folder inside `libs/agentc` populated with a `.whl` file, which you can install using
-   `pip`. Navigate to your project and install this Python wheel using your project's Python environment.
+### Installing from Source (with Poetry)
+
+1. Make sure you have Python 3.12 and [Poetry](https://python-poetry.org/docs/#installation) installed!
+
+2. Clone this repository.
+   Make sure you have your SSH key setup!
 
    ```bash
-   AGENT_CATALOG_WHEEL_FILE=$(ls $(pwd)/dist/agentc-*.whl | tr -d '\n')
-
-   # Make sure you are using your project's Python environment!
-   cd $MY_AGENT_PROJECT
-   source $MY_PYTHON_ENVIRONMENT
-
-   pip install "$AGENT_CATALOG_WHEEL_FILE"
+   git clone git@github.com:couchbaselabs/agent-catalog.git
    ```
 
-   To install the LangChain module associated with Agent Catalog, add `"[langchain]"` immediately after the wheel file:
+3. Within *your own* `pyproject.toml` file, add the following dependency to your project:
+   The `path` should point to the location of the `agentc` package (and is relative to the `pyproject.toml`
+   file itself).
+
+   ```toml
+   [tool.poetry.dependencies]
+   agentc = { path = "agent-catalog/libs/agentc", develop = true }
+   ```
+
+4. Run the command `poetry update` to install the Agent Catalog package.
 
    ```bash
-   pip install "$AGENT_CATALOG_WHEEL_FILE""[langchain]"
+   cd agent-catalog
+   poetry update
    ```
 
 ### Verifying Your Installation

--- a/docs/source/faqs.rst
+++ b/docs/source/faqs.rst
@@ -399,7 +399,8 @@ Below we give an example of how to index and publish catalogs programmatically:
        # Index the directory named tools.
        index(
               directory="tools",
-              kind="tool",
+              tools=True,
+              prompts=False
        )
 
        # Publish our local catalog.
@@ -415,7 +416,7 @@ The script above is equivalent to running the following CLI commands:
 
 .. code-block:: bash
 
-       agentc index tools --kind tool
+       agentc index tools --no-prompts
 
        export AGENT_CATALOG_CONN_STRING=localhost
        export AGENT_CATALOG_USERNAME=Administrator

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -77,7 +77,7 @@ Both tool builders and prompt builders (i.e., agent builders) will follow this w
 
    .. code-block:: bash
 
-    agentc index [DIRECTORY] --kind [tool|prompt]
+    agentc index [DIRECTORY] --prompts/no-prompts --tools/no-tools
 
    ``[DIRECTORY]`` refers to the directory containing your tools/prompts.
    This command will create a local catalog and your items will be in the newly created :file:`./agent-catalog` folder.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -9,24 +9,11 @@ Building From Package
 
 .. important::
 
-    This part is in-the-works! For now, please refer to the `Building From Source (with Poetry + pip)`_ or
-    `Building From Git (with Poetry)`_ sections below.
+    This part is in-the-works!
+    For now, please refer to the `Building From Source (with pip)`_ section below.
 
-Building From Git (with Poetry)
+Building From Source (with pip)
 -------------------------------
-
-1. Make sure you have Python 3.12 and `Poetry <https://python-poetry.org/docs/#installation>`_ installed!
-
-2. In your ``pyproject.toml`` file, add the following line in the ``[tool.poetry.dependencies]`` section:
-
-   .. code-block:: toml
-
-       agentc = { git = "git@github.com:couchbaselabs/agent-catalog.git", subdirectory = "libs/agentc", extras = ["langchain"] }
-
-3. Now run :command:`poetry update` to automatically download the ``agentc`` package into your Poetry environment.
-
-Building From Source (with Poetry + pip)
-----------------------------------------
 
 1. Make sure you have Python 3.12 and `Poetry <https://python-poetry.org/docs/#installation>`_ installed!
 
@@ -37,32 +24,53 @@ Building From Source (with Poetry + pip)
 
        git clone git@github.com:couchbaselabs/agent-catalog.git
 
-3. Build the ``agentc`` package using Poetry.
+3. You are now ready to install the Agent Catalog package!
+   Using your project's Python environment, execute the following command to install a local package with
+   :command:`pip`:
+
+   .. code-block:: bash
+
+       cd agent-catalog
+       source $MY_PYTHON_ENVIRONMENT
+
+       # Install the agentc package.
+       pip install libs/agentc
+
+   If you are interested in building a ``.whl`` file (for later use in ``.whl``-based installs), use :command:`poetry`
+   directly:
 
    .. code-block:: bash
 
        cd libs/agentc
        poetry build
 
-4. You should now have a ``dist`` folder inside ``libs/agentc`` populated with a ``.whl`` file, which you can install
-   using :command:`pip`.
-   Navigate to your project and install this Python wheel using your project's Python environment.
+Building From Source (with Poetry)
+----------------------------------
+
+1. Make sure you have Python 3.12 and `Poetry <https://python-poetry.org/docs/#installation>`_ installed!
+
+2. Clone this repository.
+   Make sure you have your SSH key setup!
 
    .. code-block:: bash
 
-       AGENT_CATALOG_WHEEL_FILE=$(ls $(pwd)/dist/agentc-*.whl | tr -d '\n')
+       git clone git@github.com:couchbaselabs/agent-catalog.git
 
-       # Make sure you are using your project's Python environment!
-       cd $MY_AGENT_PROJECT
-       source $MY_PYTHON_ENVIRONMENT
+3. Within *your own* ``pyproject.toml`` file, add the following dependency to your project:
+   The ``path`` should point to the location of the ``agentc`` package (and is relative to the ``pyproject.toml``
+   file itself).
 
-      pip install "$AGENT_CATALOG_WHEEL_FILE"
+   .. code-block:: toml
 
-   To install the LangChain module associated with Agent Catalog, add ``"[langchain]"`` immediately after the wheel file:
+       [tool.poetry.dependencies]
+       agentc = { path = "agent-catalog/libs/agentc", develop = true }
+
+4. Run the command :command:`poetry update` to install the Agent Catalog package.
 
    .. code-block:: bash
 
-      pip install "$AGENT_CATALOG_WHEEL_FILE""[langchain]"
+       cd agent-catalog
+       poetry update
 
 
 Verifying Your Installation

--- a/libs/agentc_cli/agentc_cli/cmds/index.py
+++ b/libs/agentc_cli/agentc_cli/cmds/index.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 def cmd_index(
     source_dirs: list[str | os.PathLike],
-    kind: typing.Literal["tool", "prompt"],
+    kinds: list[typing.Literal["tool", "prompt"]],
     embedding_model_name: str = DEFAULT_EMBEDDING_MODEL,
     dry_run: bool = False,
     ctx: Context = None,
@@ -73,9 +73,6 @@ def cmd_index(
         else:
             raise e
 
-    # TODO: The kind needs a security check as it's part of the path?
-    catalog_path = pathlib.Path(ctx.catalog) / (kind + DEFAULT_CATALOG_NAME)
-
     meta_version = MetaVersion(
         schema_version=CATALOG_SCHEMA_VERSION,
         library_version=lib_version(),
@@ -91,24 +88,26 @@ def cmd_index(
     else:
         printer = click.secho
 
-    printer(DASHES, fg=KIND_COLORS[kind])
-    printer(kind.upper(), bold=True, fg=KIND_COLORS[kind])
-    printer(DASHES, fg=KIND_COLORS[kind])
-    next_catalog = index_catalog(
-        embedding_model,
-        meta_version,
-        version,
-        get_path_version,
-        kind,
-        catalog_path,
-        source_dirs,
-        scan_directory_opts=DEFAULT_SCAN_DIRECTORY_OPTS,
-        printer=printer,
-        print_progress=True,
-        max_errs=DEFAULT_MAX_ERRS,
-    )
-
-    if not dry_run:
-        next_catalog.dump(catalog_path)
-        click.secho("\nCatalog successfully indexed!", fg="green")
-    click.secho(DASHES, fg=KIND_COLORS[kind])
+    for kind in kinds:
+        # TODO: The kind needs a security check as it's part of the path?
+        catalog_path = pathlib.Path(ctx.catalog) / (kind + DEFAULT_CATALOG_NAME)
+        printer(DASHES, fg=KIND_COLORS[kind])
+        printer(kind.upper(), bold=True, fg=KIND_COLORS[kind])
+        printer(DASHES, fg=KIND_COLORS[kind])
+        next_catalog = index_catalog(
+            embedding_model,
+            meta_version,
+            version,
+            get_path_version,
+            kind,
+            catalog_path,
+            source_dirs,
+            scan_directory_opts=DEFAULT_SCAN_DIRECTORY_OPTS,
+            printer=printer,
+            print_progress=True,
+            max_errs=DEFAULT_MAX_ERRS,
+        )
+        if not dry_run:
+            next_catalog.dump(catalog_path)
+            click.secho("\nCatalog successfully indexed!", fg="green")
+        click.secho(DASHES, fg=KIND_COLORS[kind])

--- a/libs/agentc_cli/agentc_cli/main.py
+++ b/libs/agentc_cli/agentc_cli/main.py
@@ -419,10 +419,17 @@ def find(
 @click_main.command()
 @click.argument("source_dirs", nargs=-1)
 @click.option(
-    "--kind",
-    default="tool",
-    type=click.Choice(["tool", "prompt"], case_sensitive=False),
-    help="Kind of items to index into the local catalog.",
+    "--prompts/--no-prompts",
+    is_flag=True,
+    default=True,
+    help="Flag to (avoid) ignoring prompt when indexing source files into the local catalog.",
+    show_default=True,
+)
+@click.option(
+    "--tools/--no-tools",
+    is_flag=True,
+    default=True,
+    help="Flag to (avoid) ignoring tools when indexing source files into the local catalog.",
     show_default=True,
 )
 @click.option(
@@ -440,7 +447,7 @@ def find(
     show_default=True,
 )
 @click.pass_context
-def index(ctx, source_dirs, kind, embedding_model, dry_run):
+def index(ctx, source_dirs, tools, prompts, embedding_model, dry_run):
     """Walk the source directory trees (SOURCE_DIRS) to index source files into the local catalog.
     Source files that will be scanned include *.py, *.sqlpp, *.yaml, etc."""
 
@@ -450,10 +457,21 @@ def index(ctx, source_dirs, kind, embedding_model, dry_run):
             "Please use the command 'agentc index --help' for more information."
         )
 
+    kinds = list()
+    if tools:
+        kinds.append("tool")
+    if prompts:
+        kinds.append("prompt")
+    if len(kinds) == 0:
+        raise ValueError(
+            "No kinds specified!\n"
+            "Please specify at least one of 'tool' (via --tools) or 'prompt' (via --prompts) to index the "
+            "source directories."
+        )
     cmd_index(
         ctx=ctx.obj,
         source_dirs=source_dirs,
-        kind=kind,
+        kinds=kinds,
         embedding_model_name=embedding_model,
         dry_run=dry_run,
     )

--- a/libs/agentc_cli/tests/test_click.py
+++ b/libs/agentc_cli/tests/test_click.py
@@ -41,7 +41,7 @@ def test_index(tmp_path):
             pathlib.Path(tool_folder / tool.parent.name).mkdir(exist_ok=True)
             shutil.copy(tool, tool_folder / tool.parent.name / (uuid.uuid4().hex + tool.suffix))
         shutil.copy(resources_folder / "_good_spec.json", tool_folder / "_good_spec.json")
-        invocation = runner.invoke(click_main, ["index", str(tool_folder.absolute())])
+        invocation = runner.invoke(click_main, ["index", str(tool_folder.absolute()), "--no-prompts"])
 
         # We should see 8 files scanned and 9 tools indexed.
         output = invocation.output

--- a/libs/agentc_cli/tests/test_click.py
+++ b/libs/agentc_cli/tests/test_click.py
@@ -43,14 +43,14 @@ def test_index(tmp_path):
         shutil.copy(resources_folder / "_good_spec.json", tool_folder / "_good_spec.json")
         invocation = runner.invoke(click_main, ["index", str(tool_folder.absolute()), "--no-prompts"])
 
-        # We should see 8 files scanned and 9 tools indexed.
+        # We should see 9 files scanned and 10 tools indexed.
         output = invocation.output
         print(output)
         assert "Crawling" in output
         assert "Generating embeddings" in output
         assert "Catalog successfully indexed" in output
-        assert "0/8" in output
         assert "0/9" in output
+        assert "0/10" in output
 
 
 # Small helper function to publish to a Couchbase catalog.

--- a/libs/agentc_core/agentc_core/tool/descriptor/models.py
+++ b/libs/agentc_core/agentc_core/tool/descriptor/models.py
@@ -69,8 +69,8 @@ class PythonToolDescriptor(RecordDescriptor):
 
 class SQLPPQueryToolDescriptor(RecordDescriptor):
     input: str
-    output: str
     query: str
+    output: typing.Optional[str] = None
     secrets: list[CouchbaseSecrets] = pydantic.Field(min_length=1, max_length=1)
     record_kind: typing.Literal[RecordKind.SQLPPQuery]
 
@@ -82,7 +82,7 @@ class SQLPPQueryToolDescriptor(RecordDescriptor):
             name: str
             description: str
             input: str
-            output: str
+            output: typing.Optional[str] = None
             secrets: list[CouchbaseSecrets] = pydantic.Field(min_length=1, max_length=1)
             record_kind: typing.Optional[typing.Literal[RecordKind.SQLPPQuery] | None] = None
             annotations: typing.Optional[dict[str, str] | None] = None
@@ -90,7 +90,8 @@ class SQLPPQueryToolDescriptor(RecordDescriptor):
             @pydantic.field_validator("input", "output")
             @classmethod
             def value_should_be_valid_json_schema(cls, v: str):
-                cls.check_if_valid_json_schema(v)
+                if v is not None:
+                    cls.check_if_valid_json_schema(v)
                 return v
 
             @pydantic.field_validator("name")

--- a/libs/agentc_core/agentc_core/tool/generate/generator.py
+++ b/libs/agentc_core/agentc_core/tool/generate/generator.py
@@ -64,11 +64,15 @@ class SQLPPCodeGenerator(_BaseCodeGenerator):
         )
 
         # ...and the output schema.
-        output_model = generate_model_from_json_schema(
-            json_schema=self.record_descriptor.output,
-            class_name=OUTPUT_MODEL_CLASS_NAME_IN_TEMPLATES,
-            python_version=self.target_python_version,
-            model_type=self.target_model_type,
+        output_model = (
+            generate_model_from_json_schema(
+                json_schema=self.record_descriptor.output,
+                class_name=OUTPUT_MODEL_CLASS_NAME_IN_TEMPLATES,
+                python_version=self.target_python_version,
+                model_type=self.target_model_type,
+            )
+            if self.record_descriptor.output is not None
+            else ""
         )
 
         # Instantiate our template.

--- a/libs/agentc_core/agentc_core/tool/templates/sqlpp_query.jinja
+++ b/libs/agentc_core/agentc_core/tool/templates/sqlpp_query.jinja
@@ -14,12 +14,12 @@ input: >
 
 # The outputs used describe the structure of the SQL++ query result.
 # Outputs are described using a JSON object that follows the JSON schema standard.
-# This field is mandatory, and will be used to build a Pydantic model.
+# This field is optional, and will be used to build a Pydantic model.
 # We recommend using the 'INFER' command to build a JSON schema from your query results.
 # See https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/infer.html.
 # In the future, this field will be optional (we will INFER the query automatically for you).
-output: >
-   <<< Replace me with your output type! >>>
+# output: >
+#    <<< Replace me with your output type! >>>
 
 # As a supplement to the tool similarity search, users can optionally specify search annotations.
 # The values of these annotations MUST be strings (e.g., not 'true', but '"true"').

--- a/libs/agentc_core/tests/tool/resources/sqlpp_query/positive_3.sqlpp
+++ b/libs/agentc_core/tests/tool/resources/sqlpp_query/positive_3.sqlpp
@@ -1,0 +1,25 @@
+/*
+name: tool_1
+
+record_kind: sqlpp_query
+
+description: >
+    i am a dummy tool
+    hello i am a dummy tool
+
+input: >
+    {
+      "type": "object",
+      "properties": {
+        "source_airport": { "type": "string" },
+        "destination_airport": { "type": "string" }
+      }
+    }
+
+secrets:
+    - couchbase:
+        conn_string: CB_CONN_STRING
+        username: CB_USERNAME
+        password: CB_PASSWORD
+*/
+SELECT 1;

--- a/libs/agentc_core/tests/tool/test_tool_validator.py
+++ b/libs/agentc_core/tests/tool/test_tool_validator.py
@@ -109,6 +109,26 @@ def test_sqlpp_query():
     assert positive_2_output_json["items"]["type"] == "object"
     assert positive_2_output_json["items"]["properties"]["airlines"]["type"] == "array"
 
+    # Test the exclusion of output.
+    positive_3_factory = _get_tool_descriptor_factory(
+        cls=SQLPPQueryToolDescriptor.Factory, filename=pathlib.Path("sqlpp_query/positive_3.sqlpp")
+    )
+    positive_3_tools = list(positive_3_factory)
+    assert len(positive_3_tools) == 1
+    assert positive_3_tools[0].name == "tool_1"
+    assert positive_3_tools[0].record_kind == RecordKind.SQLPPQuery
+    assert "SELECT 1;" in positive_3_tools[0].query
+    assert "i am a dummy tool" in positive_3_tools[0].description
+    assert "hello i am a dummy tool" in positive_3_tools[0].description
+    assert positive_3_tools[0].secrets[0].couchbase.conn_string == "CB_CONN_STRING"
+    assert positive_3_tools[0].secrets[0].couchbase.username == "CB_USERNAME"
+    assert positive_3_tools[0].secrets[0].couchbase.password == "CB_PASSWORD"
+    positive_3_input_json = json.loads(positive_3_tools[0].input)
+    assert positive_3_input_json["type"] == "object"
+    assert positive_3_input_json["properties"]["source_airport"]["type"] == "string"
+    assert positive_3_input_json["properties"]["destination_airport"]["type"] == "string"
+    assert positive_3_tools[0].output is None
+
     # Test an incomplete tool descriptor.
     negative_1_factory = _get_tool_descriptor_factory(
         cls=SQLPPQueryToolDescriptor.Factory, filename=pathlib.Path("sqlpp_query/negative_1.sqlpp")

--- a/libs/agentc_testing/agentc_testing/repo.py
+++ b/libs/agentc_testing/agentc_testing/repo.py
@@ -80,9 +80,9 @@ def initialize_repo(
     # ...otherwise, we'll call the index command.
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
     if repo_kind not in [ExampleRepoKind.INDEXED_CLEAN_PROMPTS_TRAVEL, ExampleRepoKind.PUBLISHED_PROMPTS_TRAVEL]:
-        output.append(click_runner.invoke(click_command, ["index", "tools", "--kind", "tool"] + (index_args or [])))
+        output.append(click_runner.invoke(click_command, ["index", "tools", "--no-prompts"] + (index_args or [])))
     if repo_kind not in [ExampleRepoKind.INDEXED_CLEAN_TOOLS_TRAVEL, ExampleRepoKind.PUBLISHED_TOOLS_TRAVEL]:
-        output.append(click_runner.invoke(click_command, ["index", "prompts", "--kind", "prompt"] + (index_args or [])))
+        output.append(click_runner.invoke(click_command, ["index", "prompts", "--no-tools"] + (index_args or [])))
     if repo_kind not in [
         ExampleRepoKind.PUBLISHED_ALL_TRAVEL,
         ExampleRepoKind.PUBLISHED_TOOLS_TRAVEL,

--- a/templates/tools/sqlpp_query.sqlpp
+++ b/templates/tools/sqlpp_query.sqlpp
@@ -29,23 +29,23 @@ input: >
 
 # The outputs used describe the structure of the SQL++ query result.
 # Outputs are described using a JSON object that follows the JSON schema standard.
-# This field is mandatory, and will be used to build a Pydantic model.
+# This field is optional, and will be used to build a Pydantic model.
 # We recommend using the 'INFER' command to build a JSON schema from your query results.
 # See https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/infer.html.
 # In the future, this field will be optional (we will INFER the query automatically for you).
-output: >
-    {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "cust_id": { "type": "string" },
-          "first_name": { "type": "string" },
-          "last_name": { "type": "string" },
-          "item_cnt": { "type": "integer" }
-        }
-      }
-    }
+# output: >
+#     {
+#       "type": "array",
+#       "items": {
+#         "type": "object",
+#         "properties": {
+#           "cust_id": { "type": "string" },
+#           "first_name": { "type": "string" },
+#           "last_name": { "type": "string" },
+#           "item_cnt": { "type": "integer" }
+#         }
+#       }
+#     }
 
 # As a supplement to the tool similarity search, users can optionally specify search annotations.
 # The values of these annotations MUST be strings (e.g., not 'true', but '"true"').


### PR DESCRIPTION
^ as the title says, there are some cryptic errors when trying to import tools with an output type (which currently is just the sqlpp tool). Making this field optional until this issue can be resolved.