### PR TITLE
num_candidates is now a parameter in the semantic_search tool template.

### DIFF
--- a/libs/agentc/tests/test_auditor.py
+++ b/libs/agentc/tests/test_auditor.py
@@ -1,9 +1,9 @@
 import pytest
 
-from agentc_testing.server import get_isolated_server
+from agentc_testing.server import isolated_server_factory
 
 # This is to keep ruff from falsely flagging this as unused.
-_ = get_isolated_server
+_ = isolated_server_factory
 
 
 @pytest.mark.skip
@@ -15,14 +15,14 @@ def test_local_auditor(tmp_path):
 
 @pytest.mark.skip
 @pytest.mark.regression
-def test_db_auditor(tmp_path, get_isolated_server):
+def test_db_auditor(tmp_path, isolated_server_factory):
     # TODO (GLENN): Finish me!
     pass
 
 
 @pytest.mark.skip
 @pytest.mark.regression
-def test_chain_auditor(tmp_path, get_isolated_server):
+def test_chain_auditor(tmp_path, isolated_server_factory):
     # TODO (GLENN): Finish me!
     pass
 
@@ -36,13 +36,13 @@ def test_local_auditor_no_tools(tmp_path):
 
 @pytest.mark.skip
 @pytest.mark.regression
-def test_db_auditor_no_tools(tmp_path, get_isolated_server):
+def test_db_auditor_no_tools(tmp_path, isolated_server_factory):
     # TODO (GLENN): Finish me!
     pass
 
 
 @pytest.mark.skip
 @pytest.mark.regression
-def test_chain_auditor_no_tools(tmp_path, get_isolated_server):
+def test_chain_auditor_no_tools(tmp_path, isolated_server_factory):
     # TODO (GLENN): Finish me!
     pass

--- a/libs/agentc/tests/test_provider.py
+++ b/libs/agentc/tests/test_provider.py
@@ -10,10 +10,10 @@ from agentc_core.defaults import DEFAULT_CATALOG_FOLDER
 from agentc_core.defaults import DEFAULT_TOOL_CATALOG_NAME
 from agentc_testing.repo import ExampleRepoKind
 from agentc_testing.repo import initialize_repo
-from agentc_testing.server import get_isolated_server
+from agentc_testing.server import isolated_server_factory
 
 # This is to keep ruff from falsely flagging this as unused.
-_ = get_isolated_server
+_ = isolated_server_factory
 
 
 @pytest.mark.smoke
@@ -71,9 +71,10 @@ def test_local_provider(tmp_path):
 
 
 @pytest.mark.regression
-def test_db_tool_provider(tmp_path, get_isolated_server):
+def test_db_tool_provider(tmp_path, isolated_server_factory):
     runner = click.testing.CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        isolated_server_factory(pathlib.Path(td) / ".couchbase")
         initialize_repo(
             directory=pathlib.Path(td),
             repo_kind=ExampleRepoKind.PUBLISHED_TOOLS_TRAVEL,
@@ -90,20 +91,20 @@ def test_db_tool_provider(tmp_path, get_isolated_server):
 
 @pytest.mark.skip
 @pytest.mark.regression
-def test_db_prompt_provider(tmp_path, get_isolated_server):
+def test_db_prompt_provider(tmp_path, isolated_server_factory):
     # TODO (GLENN): Finish me!
     pass
 
 
 @pytest.mark.skip
 @pytest.mark.regression
-def test_chain_tool_provider(tmp_path, get_isolated_server):
+def test_chain_tool_provider(tmp_path, isolated_server_factory):
     # TODO (GLENN): Finish me!
     pass
 
 
 @pytest.mark.skip
 @pytest.mark.regression
-def test_chain_prompt_provider(tmp_path, get_isolated_server):
+def test_chain_prompt_provider(tmp_path, isolated_server_factory):
     # TODO (GLENN): Finish me!
     pass

--- a/libs/agentc_core/agentc_core/tool/descriptor/models.py
+++ b/libs/agentc_core/agentc_core/tool/descriptor/models.py
@@ -155,6 +155,7 @@ class SemanticSearchToolDescriptor(RecordDescriptor):
             secrets: list[CouchbaseSecrets] = pydantic.Field(min_length=1, max_length=1)
             annotations: typing.Optional[dict[str, str] | None] = None
             vector_search: "SemanticSearchToolDescriptor.VectorSearchMetadata"
+            num_candidates: typing.Optional[pydantic.PositiveInt] = 3
 
             @pydantic.field_validator("input")
             @classmethod

--- a/libs/agentc_core/agentc_core/tool/templates/semantic_search.jinja
+++ b/libs/agentc_core/agentc_core/tool/templates/semantic_search.jinja
@@ -55,3 +55,7 @@ vector_search:
   # This embedding model field value is directly passed to sentence transformers.
   # In the future, we will add support for other types of embedding models.
   embedding_model: {{ embedding_model }}
+
+  # The number of candidates (i.e., the K value) to request for when performing a vector top-k search.
+  # This field is optional, and defaults to k=3 if not specified.
+  num_candidates: 3

--- a/libs/agentc_core/tests/tool/resources/semantic_search/positive_3.yaml
+++ b/libs/agentc_core/tests/tool/resources/semantic_search/positive_3.yaml
@@ -1,0 +1,33 @@
+record_kind: semantic_search
+
+name: get_travel_blog_snippets_from_user_interests
+
+description: >
+  Fetch snippets of travel blogs using a user's interests.
+
+input: >
+  {
+    "type": "object",
+    "properties": {
+      "user_interests": {
+        "type": "array",
+        "items": { "type": "string" }
+      }
+    }
+  }
+
+vector_search:
+  bucket: travel-sample
+  scope: inventory
+  collection: article
+  index: articles-index
+  vector_field: vec
+  text_field: text
+  embedding_model: sentence-transformers/all-MiniLM-L12-v2
+  num_candidates: 10
+
+secrets:
+  - couchbase:
+      conn_string: CB_CONN_STRING
+      username: CB_USERNAME
+      password: CB_PASSWORD

--- a/libs/agentc_core/tests/tool/test_tool_validator.py
+++ b/libs/agentc_core/tests/tool/test_tool_validator.py
@@ -177,9 +177,17 @@ def test_semantic_search():
         cls=SemanticSearchToolDescriptor.Factory, filename=pathlib.Path("semantic_search/positive_2.yaml")
     )
     positive_2_tools = list(positive_2_factory)
-    assert len(positive_1_tools) == 1
+    assert len(positive_2_tools) == 1
     assert positive_2_tools[0].annotations["just_for_testing"] == "false"
     assert positive_2_tools[0].annotations["gdpr_compliant"] == "true"
+
+    # Test the inclusion of the (optional) num_candidates field.
+    positive_3_factory = _get_tool_descriptor_factory(
+        cls=SemanticSearchToolDescriptor.Factory, filename=pathlib.Path("semantic_search/positive_3.yaml")
+    )
+    positive_3_tools = list(positive_3_factory)
+    assert len(positive_3_tools) == 1
+    assert positive_3_tools[0].vector_search.num_candidates == 10
 
     # Test a bad (non-Python-identifier) tool name.
     negative_1_factory = _get_tool_descriptor_factory(

--- a/templates/tools/semantic_search.yaml
+++ b/templates/tools/semantic_search.yaml
@@ -69,3 +69,7 @@ vector_search:
   # This embedding model field value is directly passed to sentence transformers.
   # In the future, we will add support for other types of embedding models.
   embedding_model: sentence-transformers/all-MiniLM-L12-v2
+
+  # The number of candidates (i.e., the K value) to request for when performing a vector top-k search.
+  # This field is optional, and defaults to k=3 if not specified.
+  num_candidates: 3


### PR DESCRIPTION
Additionally, there's a fix here to use the mock directory as the volume path for Couchbase (for agentc_testing) instead of whatever Docker does.