### PR TITLE
Use https: instead of git: for install instructions.

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -22,7 +22,7 @@ Building From Source (with pip)
 
    .. code-block:: bash
 
-       git clone git@github.com:couchbaselabs/agent-catalog.git
+          git clone https://github.com/couchbaselabs/agent-catalog
 
 3. You are now ready to install the Agent Catalog package!
    Using your project's Python environment, execute the following command to install a local package with


### PR DESCRIPTION
Install speedbump fix -- using "git clone https:..." allows for  anonymous cloning, in contrast to "git clone git:..." which needs ssh keys and github auth to be setup correctly.