### PR TITLE
ThejasNU/move cloning the repo from ssh to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ The mono-repo for the Couchbase Agent Catalog project.
 1. Make sure you have Python 3.12 and [Poetry](https://python-poetry.org/docs/#installation) installed!
 
 2. Clone this repository.
-   Make sure you have your SSH key setup!
 
    ```bash
    git clone https://github.com/couchbaselabs/agent-catalog

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The mono-repo for the Couchbase Agent Catalog project.
    Make sure you have your SSH key setup!
 
    ```bash
-   git clone git@github.com:couchbaselabs/agent-catalog.git
+   git clone https://github.com/couchbaselabs/agent-catalog
    ```
 
 3. You are now ready to install the Agent Catalog package! We recommend using Anaconda to create a virtual environment
@@ -68,7 +68,7 @@ The mono-repo for the Couchbase Agent Catalog project.
    Make sure you have your SSH key setup!
 
    ```bash
-   git clone git@github.com:couchbaselabs/agent-catalog.git
+   git clone https://github.com/couchbaselabs/agent-catalog
    ```
 
 3. Within *your own* `pyproject.toml` file, add the following dependency to your project:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ The mono-repo for the Couchbase Agent Catalog project.
 1. Make sure you have Python 3.12 and [Poetry](https://python-poetry.org/docs/#installation) installed!
 
 2. Clone this repository.
-   Make sure you have your SSH key setup!
 
    ```bash
    git clone https://github.com/couchbaselabs/agent-catalog

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -50,11 +50,10 @@ Building From Source (with Poetry)
 1. Make sure you have Python 3.12 and `Poetry <https://python-poetry.org/docs/#installation>`_ installed!
 
 2. Clone this repository.
-   Make sure you have your SSH key setup!
 
    .. code-block:: bash
 
-       git clone git@github.com:couchbaselabs/agent-catalog.git
+       git clone https://github.com/couchbaselabs/agent-catalog
 
 3. Within *your own* ``pyproject.toml`` file, add the following dependency to your project:
    The ``path`` should point to the location of the ``agentc`` package (and is relative to the ``pyproject.toml``

--- a/templates/agents/with_controlflow/README.md
+++ b/templates/agents/with_controlflow/README.md
@@ -10,7 +10,7 @@ This directory contains a starter project for building agents with Couchbase, Co
 2. Clone this repository and navigate to this directory (we will assume all subsequent commands are run from here).
 
    ```bash
-   git clone git@github.com:couchbaselabs/agent-catalog.git
+   git clone https://github.com/couchbaselabs/agent-catalog
    cd templates/agents/with_controlflow
    ```
 

--- a/templates/agents/with_controlflow/pyproject.toml
+++ b/templates/agents/with_controlflow/pyproject.toml
@@ -14,7 +14,7 @@ python = "^3.12"
 
 # The agent framework of choice.
 [tool.poetry.dependencies.controlflow]
-git = "git@github.com:PrefectHQ/ControlFlow.git"
+git = "https://github.com/PrefectHQ/ControlFlow.git"
 rev = "f259fa8144ed31b8bde5902a2de8548dd4601ce5"
 
 # TODO (GLENN): Replace this with the PyPI package once it's available.

--- a/templates/agents/with_controlflow/pyproject.toml
+++ b/templates/agents/with_controlflow/pyproject.toml
@@ -14,7 +14,7 @@ python = "^3.12"
 
 # The agent framework of choice.
 [tool.poetry.dependencies.controlflow]
-git = "https://github.com/PrefectHQ/ControlFlow.git"
+git = "https://github.com/PrefectHQ/ControlFlow"
 rev = "f259fa8144ed31b8bde5902a2de8548dd4601ce5"
 
 # TODO (GLENN): Replace this with the PyPI package once it's available.


### PR DESCRIPTION
Since the repo is public and now anybody can clone it, users(marketing/solutions team) might have to go through huge amount of steps just to setup ssh keys for agentc to work, inorder to remove that burden, git clone can be done using https avoiding ssh key setup.

I personally faced ssh key issue, when I had to set it up just for Controlflow download on the VM