### PR TITLE
Bumping up LangGraph version.

### DIFF
--- a/examples/with_langgraph/pyproject.toml
+++ b/examples/with_langgraph/pyproject.toml
@@ -11,7 +11,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.12"
-langgraph = "^0.3.7"
+langgraph = "^0.4.1"
 
 # TODO (GLENN): Replace this with the PyPI package once it's available.
 # The agentc project (the front-facing parts)!

--- a/examples/with_notebook/pyproject.toml
+++ b/examples/with_notebook/pyproject.toml
@@ -13,7 +13,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.12"
-langgraph = "^0.3.7"
+langgraph = "^0.4.1"
 couchbase = "^4.3.5"
 
 # For our Python REPL.

--- a/libs/agentc_integrations/langgraph/agentc_langgraph/graph/graph.py
+++ b/libs/agentc_integrations/langgraph/agentc_langgraph/graph/graph.py
@@ -1,5 +1,6 @@
 import abc
 import langchain_core.runnables
+import langchain_core.runnables.graph
 import langgraph.graph.graph
 import langgraph.store.base
 import typing
@@ -84,7 +85,7 @@ class GraphRunnable[S](langchain_core.runnables.Runnable):
 
     def get_graph(
         self, config: typing.Optional[langchain_core.runnables.RunnableConfig] = None
-    ) -> langgraph.graph.graph.DrawableGraph:
+    ) -> langchain_core.runnables.graph.Graph:
         graph = self.compile()
         return graph.get_graph(config=config)
 

--- a/libs/agentc_integrations/langgraph/pyproject.toml
+++ b/libs/agentc_integrations/langgraph/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.12"
 langchain-core = ">=0.2.28"
-langgraph = "^0.3.18"
+langgraph = "^0.4.1"
 langgraph-checkpointer-couchbase = "^1.0.5"
 
 # The version of this package will be updated dynamically.

--- a/libs/agentc_integrations/langgraph/tests/test_state.py
+++ b/libs/agentc_integrations/langgraph/tests/test_state.py
@@ -67,7 +67,7 @@ def test_checkpoint_saver(
         assert len(results) == 2
 
 
-@pytest.skip
+@pytest.mark.skip
 @pytest.mark.asyncio
 @pytest.mark.slow
 async def test_async_checkpoint_saver(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ click_extra = { version = "^4.15.0", extras = ["sphinx"] }
 
 # All packages for our examples (mainly here for convenience).
 [tool.poetry.group.examples.dependencies]
-langgraph = "^0.3.6"
+langgraph = "^0.4.1"
 ragas = "^0.2.14"
 jupyterlab = "^4.3.5"
 ipywidgets = "^8.1.5"


### PR DESCRIPTION
Addressing issue encountered while trying to run the LangGraph example:

```
File ".../agent-catalog/libs/agentc_integrations/langgraph/agentc_langgraph/graph/graph.py", line 87, in GraphRunnable
    ) -> langgraph.graph.graph.DrawableGraph:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'langgraph.graph.graph' has no attribute 'DrawableGraph'
```

`DrawableGraph` is just an alias for `langchain_core.runnables.graph.Graph`, so the type annotation has been updated appropriately. 