### PR TITLE
Downgrading Python from 3.13 to 3.11.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The mono-repo for the Couchbase Agent Catalog project.
 
 *Note: this section is in the works! We recommend installing from our pre-built packages in the meantime.*
 
-1. Make sure you have `python3.12` installed!
+1. Make sure you have `python3.11` installed!
 
 2. Use `pip` to install the `agentc` package.
 
@@ -41,7 +41,7 @@ The mono-repo for the Couchbase Agent Catalog project.
 
 ### Installing from Package
 
-1. Make sure you have `python3.12` installed!
+1. Make sure you have `python3.11` installed!
 
 2. Navigate to the releases page for Agent Catalog [here](https://github.com/couchbaselabs/agent-catalog/releases)
    and choose the latest version.
@@ -74,7 +74,7 @@ The mono-repo for the Couchbase Agent Catalog project.
 
 ### Installing from Source (with Makefile)
 
-1. Make sure you have `python3.12` and [`poetry`](https://python-poetry.org/docs/#installation) installed!
+1. Make sure you have `python3.11` and [`poetry`](https://python-poetry.org/docs/#installation) installed!
 
 2. Make sure you have `make` installed!
    For Mac-based installations, see [here](https://formulae.brew.sh/formula/make).
@@ -114,19 +114,22 @@ The mono-repo for the Couchbase Agent Catalog project.
    run the following command:
 
    ```bash
-   cd libs/agentc
-   poetry build
+   scripts/pre-build.sh
+   scripts/build.sh
+   scripts/post-build.sh
    ```
+
+   Your `.whl` files will end up in the `dist` folder.
 
 ### Installing from Source (with Anaconda)
 
-1. Make sure you have `python3.12` and
+1. Make sure you have `python3.11` and
    [`conda`](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html) installed!
 
 2. Create a new virtual environment with Anaconda and subsequently activate your environment.
    Again, you must activate your environment before running any `agentc` commands!
    ```bash
-   conda create -n my_agentc_env python=3.12
+   conda create -n my_agentc_env python=3.11
    conda activate my_agentc_env
    ```
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -12,7 +12,7 @@ Installing from PyPI
     This section is in the works!
     We recommend installing from our pre-built packages in the meantime.
 
-1. Make sure you have :command:`python3.12` installed!
+1. Make sure you have :command:`python3.11` installed!
 
 2. Install ``agentc`` with ``pip``.
 
@@ -43,7 +43,7 @@ Installing from PyPI
 Installing from Pre-Built Package
 ---------------------------------
 
-1. Make sure you have :command:`python3.12` installed!
+1. Make sure you have :command:`python3.11` installed!
 
 2. Navigate to the releases page for Agent Catalog `here <https://github.com/couchbaselabs/agent-catalog/releases>`__
    and choose the latest version.
@@ -74,10 +74,11 @@ Installing from Pre-Built Package
       $ pip install agentc_llamaindex-*.whl
 
 
+
 Installing from Source (with Makefile)
 --------------------------------------
 
-1. Make sure you have :command:`python3.12` and `poetry <https://python-poetry.org/docs/#installation>`__ installed!
+1. Make sure you have :command:`python3.11` and `poetry <https://python-poetry.org/docs/#installation>`__ installed!
 
 2. Make sure you have :command:`make` installed!
    For Mac-based installations, see `here <https://formulae.brew.sh/formula/make>`__.
@@ -118,13 +119,16 @@ Installing from Source (with Makefile)
 
    .. code-block:: ansi-shell-session
 
-      $ cd libs/agentc
-      $ poetry build
+      $ ./scripts/pre-build.sh
+      $ ./scripts/build.sh
+      $ ./scripts/post-build.sh
+
+   Your ``.whl`` files will end up in the `dist` folder.
 
 Installing from Source (with Anaconda)
 --------------------------------------
 
-1. Make sure you have :command:`python3.12` and
+1. Make sure you have :command:`python3.11` and
    `conda <https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html>`__ installed!
 
 2. Create a new virtual environment with Anaconda and subsequently activate your environment.
@@ -132,7 +136,7 @@ Installing from Source (with Anaconda)
 
    .. code-block:: ansi-shell-session
 
-      $ conda create -n my_agentc_env python=3.12
+      $ conda create -n my_agentc_env python=3.11
       $ conda activate my_agentc_env
 
 3. Navigate to this directory and install Agent Catalog with :command:`pip`:

--- a/examples/with_fastapi/pyproject.toml
+++ b/examples/with_fastapi/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "with-fastapi-example"
-version = "0.2.0"
+version = "0.2.1"
 description = "A starter agent built with Couchbase Agent Catalog, LangGraph, and FastAPI."
 repository = "https://github.com/couchbaselabs/agent-catalog"
 authors = [
@@ -10,7 +10,7 @@ readme = "README.md"
 package-mode = false
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 langgraph = "^0.5.2"
 fastapi = {version = "^0.116.1", extras = ["standard"]}
 

--- a/examples/with_langgraph/README.md
+++ b/examples/with_langgraph/README.md
@@ -206,6 +206,7 @@ In this section, we will illustrate how you can "tune" your agent system in an a
 
 2. Next, let's try a set of endpoints that has requires one layover.
    Specifically, we want a route from Canyonlands Field Airport (IATA 'CNY') to LAX.
+   We will restart our agent and converse with our agent accordingly:
 
    ```text
    > Assistant: Please provide the source and destination airports.

--- a/examples/with_langgraph/prompts/front_desk.yaml
+++ b/examples/with_langgraph/prompts/front_desk.yaml
@@ -24,7 +24,7 @@ output:
     needs_clarification:
       type: boolean
       description: "Whether (or not) the response needs clarification."
-  required: [ should_continue, response, needs_clarification ]
+  required: [ is_last_step, response, needs_clarification ]
 
 # As a supplement to the description similarity search, users can optionally specify search annotations.
 # The values of these annotations MUST be strings (e.g., not 'true', but '"true"').

--- a/examples/with_langgraph/pyproject.toml
+++ b/examples/with_langgraph/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "with-langgraph-example"
-version = "0.2.0"
+version = "0.2.1"
 description = "A starter agent built with Couchbase Agent Catalog and LangGraph."
 repository = "https://github.com/couchbaselabs/agent-catalog"
 authors = [
@@ -10,7 +10,7 @@ readme = "README.md"
 package-mode = false
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 langgraph = "^0.5.2"
 
 # TODO (GLENN): Replace this with the PyPI package once it's available.

--- a/examples/with_notebook/pyproject.toml
+++ b/examples/with_notebook/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "with-notebook-example"
-version = "0.2.0"
+version = "0.2.1"
 description = "A starter agent built with Couchbase Agent Catalog and LangGraph in Jupyter Notebook."
 repository = "https://github.com/couchbaselabs/agent-catalog"
 authors = [
@@ -12,7 +12,7 @@ readme = "README.md"
 package-mode = false
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 langgraph = "^0.5.2"
 couchbase = "^4.4.0"
 

--- a/libs/agentc/pyproject.toml
+++ b/libs/agentc/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 license = "Apache-2.0"
 dynamic = ["version"]
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 
 [project.urls]
 repository = "https://github.com/couchbaselabs/agent-catalog"
@@ -26,7 +26,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 pydantic-settings = "^2.7.1"
 
 # The version of these packages will be updated dynamically.

--- a/libs/agentc_cli/pyproject.toml
+++ b/libs/agentc_cli/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 license = "Apache-2.0"
 dynamic = ["version"]
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 
 [project.urls]
 repository = "https://github.com/couchbaselabs/agent-catalog"
@@ -27,7 +27,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 click-extra = "^4.15.0"
 tqdm = "^4.67.1"
 dateparser = "^1.2.2"

--- a/libs/agentc_core/agentc_core/catalog/catalog.py
+++ b/libs/agentc_core/agentc_core/catalog/catalog.py
@@ -29,7 +29,7 @@ Prompt = PromptProvider.PromptResult
 Tool = ToolProvider.ToolResult
 
 
-class Catalog[T](EmbeddingModelConfig, LocalCatalogConfig, RemoteCatalogConfig, ToolRuntimeConfig):
+class Catalog(EmbeddingModelConfig, LocalCatalogConfig, RemoteCatalogConfig, ToolRuntimeConfig):
     """A provider of indexed "agent building blocks" (e.g., tools, prompts, spans...).
 
     .. card:: Class Description
@@ -69,7 +69,7 @@ class Catalog[T](EmbeddingModelConfig, LocalCatalogConfig, RemoteCatalogConfig, 
     _local_tool_catalog: CatalogMem = None
     _remote_tool_catalog: CatalogDB = None
     _tool_catalog: CatalogBase = None
-    _tool_provider: ToolProvider[T] = None
+    _tool_provider: ToolProvider = None
 
     _local_prompt_catalog: CatalogMem = None
     _remote_prompt_catalog: CatalogDB = None
@@ -251,7 +251,7 @@ class Catalog[T](EmbeddingModelConfig, LocalCatalogConfig, RemoteCatalogConfig, 
         annotations: str = None,
         catalog_id: str = LATEST_SNAPSHOT_VERSION,
         limit: typing.Union[int | None] = 1,
-    ) -> list[Tool | T] | list[Prompt[T]] | Tool | T | Prompt[T] | None:
+    ) -> list[Tool] | list[Prompt] | Tool | Prompt | None:
         """Return a list of tools or prompts based on the specified search criteria.
 
         .. card:: Method Description
@@ -301,7 +301,7 @@ class Catalog[T](EmbeddingModelConfig, LocalCatalogConfig, RemoteCatalogConfig, 
         annotations: str = None,
         catalog_id: str = LATEST_SNAPSHOT_VERSION,
         limit: typing.Union[int | None] = 1,
-    ) -> list[Tool | T] | Tool | T | None:
+    ) -> list[Tool] | Tool | None:
         """Return a list of tools based on the specified search criteria.
 
         :param query: A query string (natural language) to search the catalog with.
@@ -337,7 +337,7 @@ class Catalog[T](EmbeddingModelConfig, LocalCatalogConfig, RemoteCatalogConfig, 
         annotations: str = None,
         catalog_id: str = LATEST_SNAPSHOT_VERSION,
         limit: typing.Union[int | None] = 1,
-    ) -> list[Prompt[T]] | Prompt[T] | None:
+    ) -> list[Prompt] | Prompt | None:
         """Return a list of prompts based on the specified search criteria.
 
         :param query: A query string (natural language) to search the catalog with.

--- a/libs/agentc_core/agentc_core/config/config.py
+++ b/libs/agentc_core/agentc_core/config/config.py
@@ -235,7 +235,7 @@ class RemoteCatalogConfig(pydantic_settings.BaseSettings):
         return cluster
 
 
-class ToolRuntimeConfig[T](pydantic_settings.BaseSettings):
+class ToolRuntimeConfig(pydantic_settings.BaseSettings):
     model_config = pydantic_settings.SettingsConfigDict(env_file=".env", env_prefix="AGENT_CATALOG_", extra="ignore")
 
     codegen_output: typing.Optional[pathlib.Path | tempfile.TemporaryDirectory | os.PathLike] = None
@@ -247,7 +247,7 @@ class ToolRuntimeConfig[T](pydantic_settings.BaseSettings):
     Python callables from these files with a "standard import".
     """
 
-    tool_decorator: typing.Optional[typing.Callable[[ToolProvider.ToolResult], T]] = None
+    tool_decorator: typing.Optional[typing.Callable[[ToolProvider.ToolResult], ...]] = None
     """ A Python decorator (function) to apply to each result yielded by :py:meth:`agentc.catalog.Catalog.find_tools`.
 
     By default, yielded results are callable and possess type annotations + documentation strings, but some agent

--- a/libs/agentc_core/agentc_core/remote/publish.py
+++ b/libs/agentc_core/agentc_core/remote/publish.py
@@ -1,4 +1,3 @@
-import base64
 import couchbase.cluster
 import couchbase.exceptions
 import datetime
@@ -8,6 +7,7 @@ import pathlib
 import pydantic
 import tqdm
 import typing
+import zlib
 
 from agentc_core.activity.models.log import Log
 from agentc_core.catalog.descriptor import CatalogDescriptor
@@ -138,10 +138,10 @@ def publish_catalog(
 
         try:
             raw_key = item.identifier + "_" + metadata["version"]["identifier"]
-            key = base64.urlsafe_b64encode(raw_key.encode()).decode()
-            if len(key) > 250:  # This is the limit on the key-length for our server. We will raise a warning here.
-                printer(f"Key value has exceeded 250 characters! Truncating key for {item.identifier}.", fg="yellow")
-                key = key[:250]
+            key = zlib.compress(raw_key.encode("utf-8")).hex()
+            if len(key) > 245:  # This is the limit on the key-length for our server. We will raise a warning here.
+                printer(f"Key value has exceeded 245 characters! Truncating key for {item.identifier}.", fg="yellow")
+                key = key[:245]
 
             progress_bar.set_description(item.name)
 

--- a/libs/agentc_core/pyproject.toml
+++ b/libs/agentc_core/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 license = "Apache-2.0"
 dynamic = ["version"]
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 
 [project.urls]
 repository = "https://github.com/couchbaselabs/agent-catalog"
@@ -30,7 +30,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 requests = "^2.32.3"
 PyYAML = "^6.0.2"
 semantic_version = "^2.10.0"

--- a/libs/agentc_integrations/langchain/pyproject.toml
+++ b/libs/agentc_integrations/langchain/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 license = "Apache-2.0"
 dynamic = ["version"]
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 
 [project.urls]
 repository = "https://github.com/couchbaselabs/agent-catalog"
@@ -22,7 +22,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 couchbase = "^4.3.6"
 joblib = "^1.4.2"
 langchain = ">=0.3.26"

--- a/libs/agentc_integrations/langgraph/agentc_langgraph/agent/agent.py
+++ b/libs/agentc_integrations/langgraph/agentc_langgraph/agent/agent.py
@@ -32,7 +32,7 @@ class State(typing.TypedDict):
     previous_node: typing.Optional[list[str]]
 
 
-class ReActAgent[S: State](langchain_core.runnables.Runnable[S, S | langgraph.types.Command]):
+class ReActAgent(langchain_core.runnables.Runnable[State, State | langgraph.types.Command]):
     """A helper ReAct agent base class that integrates with Agent Catalog.
 
     .. card:: Class Description
@@ -229,21 +229,21 @@ class ReActAgent[S: State](langchain_core.runnables.Runnable[S, S | langgraph.ty
         )
 
     def _invoke(
-        self, span: Span, state: S, config: langchain_core.runnables.RunnableConfig
-    ) -> S | langgraph.types.Command:
+        self, span: Span, state: State, config: langchain_core.runnables.RunnableConfig
+    ) -> State | langgraph.types.Command:
         pass
 
     async def _ainvoke(
-        self, span: Span, state: S, config: langchain_core.runnables.RunnableConfig
-    ) -> S | langgraph.types.Command:
+        self, span: Span, state: State, config: langchain_core.runnables.RunnableConfig
+    ) -> State | langgraph.types.Command:
         pass
 
     def invoke(
         self,
-        input: S,
+        input: State,
         config: langchain_core.runnables.RunnableConfig | None = None,
         **kwargs,
-    ) -> S | langgraph.types.Command:
+    ) -> State | langgraph.types.Command:
         node_name = self.__class__.__name__
 
         # Below, we build a Span instance which will bind all logs to our class name.
@@ -270,10 +270,10 @@ class ReActAgent[S: State](langchain_core.runnables.Runnable[S, S | langgraph.ty
 
     async def ainvoke(
         self,
-        input: S,
+        input: State,
         config: langchain_core.runnables.RunnableConfig | None = None,
         **kwargs,
-    ) -> S | langgraph.types.Command:
+    ) -> State | langgraph.types.Command:
         node_name = self.__class__.__name__
 
         # Below, we build a Span instance which will bind all logs to our class name.

--- a/libs/agentc_integrations/langgraph/agentc_langgraph/graph/graph.py
+++ b/libs/agentc_integrations/langgraph/agentc_langgraph/graph/graph.py
@@ -7,8 +7,11 @@ import typing
 from agentc_core.activity import Span
 from agentc_core.catalog import Catalog
 
+# The type of our state.
+S = typing.TypeVar("S")
 
-class GraphRunnable[S](langchain_core.runnables.Runnable):
+
+class GraphRunnable(langchain_core.runnables.Runnable):
     """A helper class that wraps the "Runnable" interface with :py:class:`agentc.Span`.
 
     .. card:: Class Description

--- a/libs/agentc_integrations/langgraph/pyproject.toml
+++ b/libs/agentc_integrations/langgraph/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 license = "Apache-2.0"
 dynamic = ["version"]
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 
 [project.urls]
 repository = "https://github.com/couchbaselabs/agent-catalog"
@@ -20,7 +20,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 langchain-core = ">=0.3.68"
 langgraph = "^0.5.1"
 langgraph-checkpointer-couchbase = "^1.0.6"

--- a/libs/agentc_integrations/llamaindex/pyproject.toml
+++ b/libs/agentc_integrations/llamaindex/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 license = "Apache-2.0"
 dynamic = ["version"]
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 
 [project.urls]
 repository = "https://github.com/couchbaselabs/agent-catalog"
@@ -25,7 +25,7 @@ Documentation = "https://docs.couchbase.com"
 Repository = "https://github.com/couchbaselabs/agent-catalog"
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 couchbase = "^4.3.6"
 joblib = "^1.4.2"
 llama-index = "^0.12.47"

--- a/libs/agentc_testing/pyproject.toml
+++ b/libs/agentc_testing/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 license = "Apache-2.0"
 dynamic = ["version"]
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 
 [tool.poetry]
 name = "agentc-testing"
@@ -17,7 +17,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 pre-commit = "^3.2.2"
 pytest = "^8.3.2"
 docker = "^7.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 license = "Apache-2.0"
 readme = "README.md"
 dynamic = ["version"]
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 
 [project.urls]
 repository = "https://github.com/couchbaselabs/agent-catalog"
@@ -23,7 +23,7 @@ version = "0.0.0"
 package-mode = false
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 
 # All of our Agent Catalog packages.
 agentc = { path = "libs/agentc", develop = true }
@@ -38,6 +38,7 @@ pre-commit = "^3.2.2"
 pytest = "^8.3.2"
 pytest-retry = "^1.7.0"
 pytest-asyncio = "^1.1.0"
+virtualenv = "<20.33.0"
 
 # An internal testing package for the Agent Catalog.
 [tool.poetry.group.dev.dependencies.agentc-testing]
@@ -117,7 +118,7 @@ files = [
 ]
 
 [tool.poetry.requires-plugins]
-poetry-plugin-export = ">=1.8"
+poetry-plugin-export = ">=1.9"
 poetry-dynamic-versioning = { version = ">=1.0.0,<2.0.0", extras = ["plugin"] }
 
 [build-system]


### PR DESCRIPTION
- No longer using 3.13-style generics. This downgrade to 3.11 is necessary to play nice with Google Colab environments, and doesn't break our existing examples.
- Publish now uses a base-64-encoded version of the item + catalog identifier -- this is to get around the 250-character key-length restriction.