### PR TITLE
fix(remote): narrow exception handling in FTS index DDL helpers

### DIFF
--- a/libs/agentc_core/agentc_core/remote/util/ddl.py
+++ b/libs/agentc_core/agentc_core/remote/util/ddl.py
@@ -81,10 +81,12 @@ def is_fts_index_present(
             else:
                 raise RuntimeError("Couldn't check for the existing vector indexes!")
 
-        # TODO (GLENN): Catch a narrower exception here + log the fact an exception was raised.
-        except Exception as e:
-            logger.debug(f"Swallowing exception {str(e)}.")
+        except requests.exceptions.RequestException as e:
+            logger.debug(f"Could not reach FTS node '{fts_node_hostname}': {str(e)}. Trying next node.")
             continue
+        except (ValueError, KeyError, RuntimeError) as e:
+            logger.error(f"Received a malformed or error response from FTS node '{fts_node_hostname}': {str(e)}")
+            return False, e
 
     # if there is exception in all nodes then no nodes are alive
     return False, RuntimeError("Couldn't make request to any of the nodes with 'search' service!")
@@ -121,8 +123,11 @@ def get_fts_nodes_hostname(cfg: Config) -> tuple[list[str] | None, Exception | N
         else:
             return None, RuntimeError("Couldn't check for the existing fts nodes!")
 
-    # TODO (GLENN): Catch a narrower exception here + log the fact an exception was raised.
-    except Exception as e:
+    except requests.exceptions.RequestException as e:
+        logger.debug(f"Could not reach host '{host}': {str(e)}.")
+        return None, e
+    except (ValueError, KeyError) as e:
+        logger.error(f"Received a malformed response from host '{host}': {str(e)}")
         return None, e
 
 
@@ -245,16 +250,19 @@ def create_vector_index(
                         "PUT", create_vector_index_http_url, headers=headers, auth=auth, data=payload
                     )
 
-                if json.loads(response.text)["status"] == "ok":
+                json_response = json.loads(response.text)
+                if json_response["status"] == "ok":
                     logger.info("Created vector index!!")
                     return qualified_index_name, None
-                elif json.loads(response.text)["status"] == "fail":
-                    raise Exception(json.loads(response.text)["error"])
+                elif json_response["status"] == "fail":
+                    raise RuntimeError(json_response["error"])
 
-            # TODO (GLENN): Catch a narrower exception here + log the fact an exception was raised.
-            except Exception as e:
-                logger.debug(f"Swallowing exception {str(e)}.")
+            except requests.exceptions.RequestException as e:
+                logger.debug(f"Could not reach FTS node '{fts_node_hostname}': {str(e)}. Trying next node.")
                 continue
+            except (ValueError, KeyError, RuntimeError) as e:
+                logger.error(f"Received a malformed or error response from FTS node '{fts_node_hostname}': {str(e)}")
+                return None, e
 
         # if there is exception in all nodes then no nodes are alive
         return None, RuntimeError("Couldn't make request to any of the nodes with 'search' service!")
@@ -326,22 +334,19 @@ def create_vector_index(
                         "PUT", update_vector_index_http_url, headers=headers, auth=auth, data=payload
                     )
 
-                if json.loads(response.text)["status"] == "ok":
+                json_response = json.loads(response.text)
+                if json_response["status"] == "ok":
                     logger.info("Updated vector index!!")
                     return "Success", None
-                elif json.loads(response.text)["status"] == "fail":
-                    raise Exception(json.loads(response.text)["error"])
+                elif json_response["status"] == "fail":
+                    raise RuntimeError(json_response["error"])
 
-                if json.loads(response.text)["status"] == "ok":
-                    logger.info("Updated vector index!!")
-                    return "Success", None
-                elif json.loads(response.text)["status"] == "fail":
-                    raise Exception(json.loads(response.text)["error"])
-
-            # TODO (GLENN): Catch a narrower exception here + log the fact an exception was raised.
-            except Exception as e:
-                logger.debug(f"Swallowing exception {str(e)}.")
+            except requests.exceptions.RequestException as e:
+                logger.debug(f"Could not reach FTS node '{fts_node_hostname}': {str(e)}. Trying next node.")
                 continue
+            except (ValueError, KeyError, RuntimeError) as e:
+                logger.error(f"Received a malformed or error response from FTS node '{fts_node_hostname}': {str(e)}")
+                return None, e
 
         # if there is exception in all nodes then no nodes are alive
         return None, RuntimeError("Couldn't make request to any of the nodes with 'search' service!")

--- a/libs/agentc_core/tests/remote/util/test_ddl.py
+++ b/libs/agentc_core/tests/remote/util/test_ddl.py
@@ -1,0 +1,115 @@
+import json
+import pytest
+import requests
+import unittest.mock
+
+from agentc_core.config import Config
+from agentc_core.remote.util.ddl import get_fts_nodes_hostname
+from agentc_core.remote.util.ddl import is_fts_index_present
+
+
+@pytest.fixture
+def cfg():
+    return Config(
+        conn_string="couchbase://localhost",
+        username="Administrator",
+        password="password",
+        bucket="travel-sample",
+    )
+
+
+def _response(status_code=200, text=""):
+    response = unittest.mock.Mock()
+    response.status_code = status_code
+    response.text = text
+    return response
+
+
+@pytest.mark.smoke
+def test_is_fts_index_present_returns_index_def_on_ok(cfg):
+    index_def = {"name": "my_index"}
+    body = json.dumps({"status": "ok", "indexDefs": {"indexDefs": {"my_index": index_def}}})
+    with unittest.mock.patch("requests.request", return_value=_response(text=body)):
+        result, err = is_fts_index_present(cfg, "my_index", ["node1"])
+    assert err is None
+    assert result == index_def
+
+
+@pytest.mark.smoke
+def test_is_fts_index_present_returns_false_when_index_missing(cfg):
+    body = json.dumps({"status": "ok", "indexDefs": {"indexDefs": {"other_index": {}}}})
+    with unittest.mock.patch("requests.request", return_value=_response(text=body)):
+        result, err = is_fts_index_present(cfg, "my_index", ["node1"])
+    assert err is None
+    assert result is False
+
+
+@pytest.mark.smoke
+def test_is_fts_index_present_retries_next_node_on_connection_error(cfg):
+    body = json.dumps({"status": "ok", "indexDefs": None})
+    with unittest.mock.patch(
+        "requests.request",
+        side_effect=[requests.exceptions.ConnectionError("node1 is down"), _response(text=body)],
+    ) as mock_request:
+        result, err = is_fts_index_present(cfg, "my_index", ["node1", "node2"])
+    assert err is None
+    assert result is False
+    assert mock_request.call_count == 2
+
+
+@pytest.mark.smoke
+def test_is_fts_index_present_returns_error_on_malformed_response(cfg):
+    with unittest.mock.patch("requests.request", return_value=_response(text="not json")):
+        result, err = is_fts_index_present(cfg, "my_index", ["node1"])
+    assert result is False
+    assert isinstance(err, ValueError)
+
+
+@pytest.mark.smoke
+def test_is_fts_index_present_returns_error_when_status_not_ok(cfg):
+    body = json.dumps({"status": "fail"})
+    with unittest.mock.patch("requests.request", return_value=_response(text=body)):
+        result, err = is_fts_index_present(cfg, "my_index", ["node1"])
+    assert result is False
+    assert isinstance(err, RuntimeError)
+
+
+@pytest.mark.smoke
+def test_is_fts_index_present_returns_error_when_all_nodes_down(cfg):
+    with unittest.mock.patch("requests.request", side_effect=requests.exceptions.ConnectionError("down")):
+        result, err = is_fts_index_present(cfg, "my_index", ["node1", "node2"])
+    assert result is False
+    assert isinstance(err, RuntimeError)
+
+
+@pytest.mark.smoke
+def test_get_fts_nodes_hostname_returns_nodes_on_ok(cfg):
+    body = json.dumps(
+        {
+            "name": "default",
+            "nodes": [
+                {"services": ["fts", "kv"], "configuredHostname": "node1:8091"},
+                {"services": ["kv"], "configuredHostname": "node2:8091"},
+            ],
+        }
+    )
+    with unittest.mock.patch("requests.request", return_value=_response(text=body)):
+        nodes, err = get_fts_nodes_hostname(cfg)
+    assert err is None
+    assert nodes == ["node1"]
+
+
+@pytest.mark.smoke
+def test_get_fts_nodes_hostname_returns_connection_error(cfg):
+    with unittest.mock.patch("requests.request", side_effect=requests.exceptions.ConnectionError("host is down")):
+        nodes, err = get_fts_nodes_hostname(cfg)
+    assert nodes is None
+    assert isinstance(err, requests.exceptions.ConnectionError)
+
+
+@pytest.mark.smoke
+def test_get_fts_nodes_hostname_returns_error_on_malformed_response(cfg):
+    with unittest.mock.patch("requests.request", return_value=_response(text="not json")):
+        nodes, err = get_fts_nodes_hostname(cfg)
+    assert nodes is None
+    assert isinstance(err, ValueError)


### PR DESCRIPTION
### fix(remote): narrow exception handling in FTS index DDL helpers

- Is FTS index present, get FTS nodes hostname, now catch only **requests.exceptions.RequestException** as a retryable, per node failure. Malformed responses and explicit failure statuses raise value error, key error, runtime error, which are logged and returned instead of silently swallowed.

- Applied to create vector index, create and update, which now parses response.text once instead of three times. Removed duplicate block **335-339** in the update path that was an unreachable copy of **329-333**.

- Wrote test DDL. **9/9** tests passing that cover happy path, per node retry on connection error, malformed responses, explicit failure status and all nodes down.

<img width="800" height="466" alt="Screenshot 2026-07-10 at 10 41 02 AM" src="https://github.com/user-attachments/assets/a98e7cdc-a5a5-4e83-9631-d9360799ca38" />