### PR TITLE
fix(logger): guard runtime log insert against transient Couchbase errors

### DIFF
--- a/libs/agentc_core/agentc_core/activity/logger/chain.py
+++ b/libs/agentc_core/agentc_core/activity/logger/chain.py
@@ -18,5 +18,7 @@ class ChainLogger(BaseLogger):
         self.local_logger = local_logger
 
     def _accept(self, log_obj: Log, log_json: dict):
-        self.db_logger._accept(log_obj, log_json)
+        # We write locally first: the local log is our durable fallback, so a slow or failing cluster must never cost
+        # us the on-disk copy of a record.
         self.local_logger._accept(log_obj, log_json)
+        self.db_logger._accept(log_obj, log_json)

--- a/libs/agentc_core/agentc_core/activity/logger/db.py
+++ b/libs/agentc_core/agentc_core/activity/logger/db.py
@@ -1,3 +1,4 @@
+import couchbase.exceptions
 import couchbase.options
 import logging
 import textwrap
@@ -43,5 +44,20 @@ class DBLogger(BaseLogger):
         # Grab our TTL for our logs.
         self.ttl = cfg.log_ttl
 
+        # The number of log records we have failed to write to Couchbase (see _accept below).
+        self.dropped_log_count = 0
+
     def _accept(self, log_obj: Log, log_json: dict):
-        self.cb_coll.insert(log_obj.identifier, log_json, couchbase.options.InsertOptions(expiry=self.ttl))
+        try:
+            self.cb_coll.insert(log_obj.identifier, log_json, couchbase.options.InsertOptions(expiry=self.ttl))
+        except couchbase.exceptions.CouchbaseException as e:
+            # An agent should never crash because its activity log could not be written. We warn (instead of raising)
+            # and continue, mirroring how we handle a cluster that is unreachable at Span-instantiation time.
+            self.dropped_log_count += 1
+            logger.warning(
+                "Could not write the log record %s to Couchbase (%d record(s) dropped for this logger so far). "
+                "Swallowing exception %s.",
+                log_obj.identifier,
+                self.dropped_log_count,
+                str(e),
+            )

--- a/libs/agentc_core/tests/activity/test_logger_resilience.py
+++ b/libs/agentc_core/tests/activity/test_logger_resilience.py
@@ -1,0 +1,140 @@
+import couchbase.exceptions
+import datetime
+import logging
+import pytest
+
+from agentc_core.activity.logger import ChainLogger
+from agentc_core.activity.logger import DBLogger
+from agentc_core.activity.models.content import SystemContent
+from agentc_core.version import VersionDescriptor
+
+
+class _FailingCollection:
+    """A collection whose insert always raises the given (transient) Couchbase error."""
+
+    def __init__(self, exception: Exception):
+        self.exception = exception
+        self.attempts = 0
+
+    def insert(self, *args, **kwargs):
+        self.attempts += 1
+        raise self.exception
+
+
+class _RecordingCollection:
+    def __init__(self):
+        self.documents = dict()
+
+    def insert(self, key, value, *args, **kwargs):
+        self.documents[key] = value
+
+
+def _db_logger(collection) -> DBLogger:
+    # Note: we bypass __init__ here to avoid requiring a live cluster for these tests.
+    db_logger = DBLogger.__new__(DBLogger)
+    db_logger.catalog_version = VersionDescriptor(
+        is_dirty=False,
+        identifier="my_catalog_version",
+        timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
+    )
+    db_logger.annotations = dict()
+    db_logger.cb_coll = collection
+    db_logger.ttl = datetime.timedelta(seconds=100)
+    db_logger.dropped_log_count = 0
+    return db_logger
+
+
+class _RecordingLocalLogger:
+    def __init__(self, catalog_version: VersionDescriptor):
+        self.catalog_version = catalog_version
+        self.annotations = dict()
+        self.records = list()
+
+    def _accept(self, log_obj, log_json):
+        self.records.append(log_json)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "exception",
+    [
+        couchbase.exceptions.TimeoutException("timed out"),
+        couchbase.exceptions.UnAmbiguousTimeoutException("unambiguous timeout"),
+        couchbase.exceptions.TemporaryFailException("temporary failure"),
+        couchbase.exceptions.DocumentExistsException("already exists"),
+    ],
+)
+def test_db_logger_swallows_couchbase_errors(exception: Exception, caplog: pytest.LogCaptureFixture):
+    collection = _FailingCollection(exception)
+    db_logger = _db_logger(collection)
+
+    with caplog.at_level(logging.WARNING, logger="agentc_core.activity.logger.db"):
+        # A failed write must not propagate into the calling agent...
+        message = db_logger.log(
+            content=SystemContent(value="Hello world!"), span_name=["my_span"], session_id="my_session"
+        )
+
+    # ...but it must be recorded (both in our warning log and in our dropped-record count).
+    assert collection.attempts == 1
+    assert message.content.value == "Hello world!"
+    assert db_logger.dropped_log_count == 1
+    assert any(message.identifier in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.smoke
+def test_db_logger_records_repeated_failures():
+    db_logger = _db_logger(_FailingCollection(couchbase.exceptions.TimeoutException("timed out")))
+    for _ in range(3):
+        db_logger.log(content=SystemContent(value="Hello world!"), span_name=["my_span"], session_id="my_session")
+    assert db_logger.dropped_log_count == 3
+
+
+@pytest.mark.smoke
+def test_db_logger_does_not_swallow_non_couchbase_errors():
+    class _ExplodingCollection:
+        def insert(self, *args, **kwargs):
+            raise RuntimeError("this is a bug, not a transient cluster error")
+
+    db_logger = _db_logger(_ExplodingCollection())
+    with pytest.raises(RuntimeError):
+        db_logger.log(content=SystemContent(value="Hello world!"), span_name=["my_span"], session_id="my_session")
+
+
+@pytest.mark.smoke
+def test_db_logger_writes_on_healthy_cluster():
+    collection = _RecordingCollection()
+    db_logger = _db_logger(collection)
+    message = db_logger.log(content=SystemContent(value="Hello world!"), span_name=["my_span"], session_id="my_session")
+    assert list(collection.documents.keys()) == [message.identifier]
+    assert collection.documents[message.identifier]["content"]["value"] == "Hello world!"
+    assert db_logger.dropped_log_count == 0
+
+
+@pytest.mark.smoke
+def test_chain_logger_writes_locally_when_cluster_fails():
+    db_logger = _db_logger(_FailingCollection(couchbase.exceptions.TimeoutException("timed out")))
+    local_logger = _RecordingLocalLogger(db_logger.catalog_version)
+    chain_logger = ChainLogger(local_logger=local_logger, db_logger=db_logger)
+
+    message = chain_logger.log(
+        content=SystemContent(value="Hello world!"), span_name=["my_span"], session_id="my_session"
+    )
+
+    # The local (durable) copy must survive a failing cluster.
+    assert len(local_logger.records) == 1
+    assert local_logger.records[0]["identifier"] == message.identifier
+    assert db_logger.dropped_log_count == 1
+
+
+@pytest.mark.smoke
+def test_chain_logger_writes_to_both_sinks():
+    collection = _RecordingCollection()
+    db_logger = _db_logger(collection)
+    local_logger = _RecordingLocalLogger(db_logger.catalog_version)
+    chain_logger = ChainLogger(local_logger=local_logger, db_logger=db_logger)
+
+    message = chain_logger.log(
+        content=SystemContent(value="Hello world!"), span_name=["my_span"], session_id="my_session"
+    )
+    assert len(local_logger.records) == 1
+    assert list(collection.documents.keys()) == [message.identifier]


### PR DESCRIPTION
Every **span.log()** ran a bare **cb_coll.insert()** in **DBLogger._accept**, so any KV error (rebalance, failover, timeouts, Temp Fail Exceptions under load, duplicate IDs) surfaces in the agent's code.

At Enterprise volume, a few seconds of cluster pressure could take down the workload the logger exists to observe.

The insert is now wrapped in a Couchbase Exception, warns with the log ID, bumps a running dropped_log_count, and keeps going.

Other errors still raise, this is not a Blanket Exception.

In **chain.py**, the local file write now runs before the remote write, so the on disk fallback survives a bad cluster instead of being skipped when it matters most.

Tests: 9 tests in test logger resilience, no server needed.

6 of these 9 fail before the fix. All 9 pass after.

<img width="328" height="372" alt="Screenshot 2026-08-12 at 10 04 52 AM" src="https://github.com/user-attachments/assets/44ade82a-1cee-42fc-a7c2-b3d3ea3b3892" />

<img width="452" height="621" alt="Screenshot 2026-08-12 at 10 02 51 AM" src="https://github.com/user-attachments/assets/12b5bfa6-921c-4237-82e4-48feefc6d6c8" />